### PR TITLE
Disable play leave finished room

### DIFF
--- a/src/lobby/Lobbies.jsx
+++ b/src/lobby/Lobbies.jsx
@@ -6,8 +6,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEye, faEyeSlash, faTrophy } from '@fortawesome/free-solid-svg-icons';
 import _ from 'lodash';
 
-const joinableRoom = (playerName) => ({ roundsPlayed, players, ...rest }) => {
-  if (roundsPlayed === 16) {
+const joinableRoom = (playerName) => ({ roundsPlayed, players, maxRounds, ...rest }) => {
+  if (roundsPlayed === maxRounds) {
     return false;
   }
 

--- a/src/lobby/room-instance.jsx
+++ b/src/lobby/room-instance.jsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 
 const LobbyRoom = (props) => {
   const room = props.room;
+  const roomActive = room.roundsPlayed != room.maxRounds;
   const freeSeat = room.players.find((player) => !player.name);
   const playerSeat = room.players.find(
     (player) => player.name === props.playerName
@@ -82,7 +83,7 @@ ${activePlayerId === player.id ? 'text-primary' : 'text-muted'}
       </td>
       <td className="text-right align-middle h-100">
         <div className="d-flex justify-content-end">
-          {playerSeat && (
+          {roomActive && playerSeat && (
             <div className="my-1">
               <button
                 className={`mx-1 btn btn-text bg-primary ${
@@ -97,7 +98,7 @@ ${activePlayerId === player.id ? 'text-primary' : 'text-muted'}
             </div>
           )}
 
-          {playerSeat && !freeSeat && (
+          {roomActive && playerSeat && !freeSeat && (
             <div className="my-1">
               <Link
                 to={`/games/klaver-jassen/${room.gameID}`}
@@ -108,7 +109,7 @@ ${activePlayerId === player.id ? 'text-primary' : 'text-muted'}
               </Link>
             </div>
           )}
-          {!playerSeat && !freeSeat && (
+          {(!roomActive || (!playerSeat && !freeSeat)) && (
             <div className="my-1">
               <Link
                 to={`/games/klaver-jassen/${room.gameID}`}

--- a/src/lobby/room-instance.jsx
+++ b/src/lobby/room-instance.jsx
@@ -7,7 +7,7 @@ import { Link } from 'react-router-dom';
 
 const LobbyRoom = (props) => {
   const room = props.room;
-  const roomActive = room.roundsPlayed != room.maxRounds;
+  const roomActive = room.roundsPlayed !== room.maxRounds;
   const freeSeat = room.players.find((player) => !player.name);
   const playerSeat = room.players.find(
     (player) => player.name === props.playerName


### PR DESCRIPTION
When a game is finished, players can no longer join or leave the room. 
Instead, players can only spectate a finished game whether they took part in the game or not.

Fixed #27